### PR TITLE
Update PostgreSQLQuoting's `type_cast` method

### DIFF
--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -219,7 +219,9 @@ module ActiveUUID
         def type_cast(value, column = nil, *args)
           value = UUIDTools::UUID.serialize(value) if column && column.type == :uuid
           value = value.to_s if value.is_a? UUIDTools::UUID
-          super(value, column, *args)
+          # NOTE: commenting the below line and going with value param only because this line is crashing Activerecord 7.0.x queries
+          # super(value, column, *args)
+          super(value)
         end
 
         def native_database_types


### PR DESCRIPTION
Modified `type_cast` method in the patch because new Rails 7 Activerecord's postgresql adapted calls with one param `value` instead of three params.